### PR TITLE
Honor CC, CXX, CFLAGS and CXXFLAGS environment

### DIFF
--- a/7zip/Makefile
+++ b/7zip/Makefile
@@ -1,8 +1,8 @@
-CC = gcc
-CXX = g++
+CC ?= gcc
+CXX ?= g++
 
-CFLAGS = -W -Wall -Wextra -O2
-CXXFLAGS = -W -Wall -Wextra -std=c++11 -O2 -ICPP
+CFLAGS += -W -Wall -Wextra -O2
+CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -ICPP
 
 7ZIP_CXX_SRC = CPP/7zip/Archive/Common/ParseProperties.cpp \
                CPP/7zip/Archive/DeflateProps.cpp \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-CC = gcc
-CXX = g++
+CC ?= gcc
+CXX ?= g++
 
-CFLAGS = -W -Wall -Wextra -O2 -Wno-implicit-function-declaration -DNDEBUG=1
-CXXFLAGS = -W -Wall -Wextra -std=c++11 -O2 -Izopfli/src -I7zip -DNDEBUG=1 \
+CFLAGS += -W -Wall -Wextra -O2 -Wno-implicit-function-declaration -DNDEBUG=1
+CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -Izopfli/src -I7zip -DNDEBUG=1 \
 	-Wno-unused-parameter -pthread
 
 SRC_CXX_SRC = $(wildcard src/*.cpp)

--- a/zopfli/Makefile
+++ b/zopfli/Makefile
@@ -1,8 +1,8 @@
-CC = gcc
-CXX = g++
+CC ?= gcc
+CXX ?= g++
 
-CFLAGS = -W -Wall -Wextra -ansi -pedantic -lm -O2 -Wno-unused-function
-CXXFLAGS = -W -Wall -Wextra -ansi -pedantic -O2
+CFLAGS += -W -Wall -Wextra -ansi -pedantic -lm -O2 -Wno-unused-function
+CXXFLAGS += -W -Wall -Wextra -ansi -pedantic -O2
 
 ZOPFLILIB_SRC = src/zopfli/blocksplitter.c src/zopfli/cache.c\
                 src/zopfli/deflate.c src/zopfli/gzip_container.c\


### PR DESCRIPTION
If CC or CXX is set trough the environment use those instead of
hard coding gcc on unix. Also add build environments CFLAGS and CXXFLAGS
to makefiles CFLAGS and CXXFLAGS.

The former allows to use different compilers then gcc in build
environments without the need to run make with the -e flag.

The second allows to add build system relevant build flags to the build
process (e.g. security related flags in packaging) while still honoring
the ones provided by the makefile itself.