### PR TITLE
Allow compression to a DAX file

### DIFF
--- a/7zip/7zip.vcxproj
+++ b/7zip/7zip.vcxproj
@@ -23,9 +23,14 @@
     <ClInclude Include="CPP\7zip\Archive\DeflateProps.h" />
     <ClInclude Include="CPP\7zip\Common\CWrappers.h" />
     <ClInclude Include="CPP\7zip\Common\FileStreams.h" />
+    <ClInclude Include="CPP\7zip\Common\InBuffer.h" />
     <ClInclude Include="CPP\7zip\Common\OutBuffer.h" />
     <ClInclude Include="CPP\7zip\Common\StreamUtils.h" />
+    <ClInclude Include="CPP\7zip\Compress\DeflateDecoder.h" />
     <ClInclude Include="CPP\7zip\Compress\DeflateEncoder.h" />
+    <ClInclude Include="CPP\7zip\Compress\LzOutWindow.h" />
+    <ClInclude Include="CPP\7zip\Compress\ZlibDecoder.h" />
+    <ClInclude Include="CPP\7zip\Compress\ZlibEncoder.h" />
     <ClInclude Include="CPP\Common\MyString.h" />
     <ClInclude Include="CPP\Common\StringConvert.h" />
     <ClInclude Include="CPP\Common\StringToInt.h" />
@@ -42,9 +47,15 @@
     <ClCompile Include="CPP\7zip\Archive\DeflateProps.cpp" />
     <ClCompile Include="CPP\7zip\Common\CWrappers.cpp" />
     <ClCompile Include="CPP\7zip\Common\FileStreams.cpp" />
+    <ClCompile Include="CPP\7zip\Common\InBuffer.cpp" />
     <ClCompile Include="CPP\7zip\Common\OutBuffer.cpp" />
     <ClCompile Include="CPP\7zip\Common\StreamUtils.cpp" />
+    <ClCompile Include="CPP\7zip\Compress\BitlDecoder.cpp" />
+    <ClCompile Include="CPP\7zip\Compress\DeflateDecoder.cpp" />
     <ClCompile Include="CPP\7zip\Compress\DeflateEncoder.cpp" />
+    <ClCompile Include="CPP\7zip\Compress\LzOutWindow.cpp" />
+    <ClCompile Include="CPP\7zip\Compress\ZlibDecoder.cpp" />
+    <ClCompile Include="CPP\7zip\Compress\ZlibEncoder.cpp" />
     <ClCompile Include="CPP\Common\MyString.cpp" />
     <ClCompile Include="CPP\Common\StringConvert.cpp" />
     <ClCompile Include="CPP\Common\StringToInt.cpp" />
@@ -55,6 +66,9 @@
     <ClCompile Include="C\LzFind.c" />
     <ClCompile Include="C\Sort.c" />
     <ClCompile Include="deflate7z.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Makefile" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6343B36E-030F-4A66-A588-758B2E2B5BEE}</ProjectGuid>

--- a/7zip/7zip.vcxproj.filters
+++ b/7zip/7zip.vcxproj.filters
@@ -55,6 +55,21 @@
     <ClInclude Include="CPP\7zip\Common\StreamUtils.h">
       <Filter>7zip</Filter>
     </ClInclude>
+    <ClInclude Include="CPP\7zip\Compress\ZlibEncoder.h">
+      <Filter>7zip</Filter>
+    </ClInclude>
+    <ClInclude Include="CPP\7zip\Compress\ZlibDecoder.h">
+      <Filter>7zip</Filter>
+    </ClInclude>
+    <ClInclude Include="CPP\7zip\Compress\DeflateDecoder.h">
+      <Filter>7zip</Filter>
+    </ClInclude>
+    <ClInclude Include="CPP\7zip\Compress\LzOutWindow.h">
+      <Filter>7zip</Filter>
+    </ClInclude>
+    <ClInclude Include="CPP\7zip\Common\InBuffer.h">
+      <Filter>7zip</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CPP\7zip\Archive\DeflateProps.cpp">
@@ -106,5 +121,26 @@
     <ClCompile Include="CPP\7zip\Common\StreamUtils.cpp">
       <Filter>7zip</Filter>
     </ClCompile>
+    <ClCompile Include="CPP\7zip\Compress\ZlibEncoder.cpp">
+      <Filter>7zip</Filter>
+    </ClCompile>
+    <ClCompile Include="CPP\7zip\Compress\ZlibDecoder.cpp">
+      <Filter>7zip</Filter>
+    </ClCompile>
+    <ClCompile Include="CPP\7zip\Compress\DeflateDecoder.cpp">
+      <Filter>7zip</Filter>
+    </ClCompile>
+    <ClCompile Include="CPP\7zip\Compress\LzOutWindow.cpp">
+      <Filter>7zip</Filter>
+    </ClCompile>
+    <ClCompile Include="CPP\7zip\Common\InBuffer.cpp">
+      <Filter>7zip</Filter>
+    </ClCompile>
+    <ClCompile Include="CPP\7zip\Compress\BitlDecoder.cpp">
+      <Filter>7zip</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Makefile" />
   </ItemGroup>
 </Project>

--- a/7zip/Makefile
+++ b/7zip/Makefile
@@ -1,5 +1,6 @@
 CC ?= gcc
 CXX ?= g++
+AR ?= ar
 
 CFLAGS += -W -Wall -Wextra -O2
 CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -ICPP
@@ -32,7 +33,7 @@ CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -ICPP
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 7zip.a: $(7ZIP_CXX_OBJ) $(7ZIP_C_OBJ)
-	ar rcs $@ $^
+	$(AR) rcs $@ $^
 
 clean:
 	rm -f $(7ZIP_CXX_OBJ) $(7ZIP_C_OBJ) 7zip.a

--- a/7zip/Makefile
+++ b/7zip/Makefile
@@ -9,9 +9,15 @@ CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -ICPP
                CPP/7zip/Archive/DeflateProps.cpp \
                CPP/7zip/Common/CWrappers.cpp \
                CPP/7zip/Common/FileStreams.cpp \
+               CPP/7zip/Common/InBuffer.cpp \
                CPP/7zip/Common/OutBuffer.cpp \
                CPP/7zip/Common/StreamUtils.cpp \
+               CPP/7zip/Compress/BitlDecoder.cpp \
+               CPP/7zip/Compress/DeflateDecoder.cpp \
                CPP/7zip/Compress/DeflateEncoder.cpp \
+               CPP/7zip/Compress/LzOutWindow.cpp \
+               CPP/7zip/Compress/ZlibDecoder.cpp \
+               CPP/7zip/Compress/ZlibEncoder.cpp \
                CPP/Common/MyString.cpp \
                CPP/Common/StringConvert.cpp \
                CPP/Common/StringToInt.cpp \

--- a/7zip/deflate7z.h
+++ b/7zip/deflate7z.h
@@ -10,6 +10,7 @@ namespace Deflate7z {
 		uint32_t fastbytes;
 		uint32_t algo;
 		uint32_t matchcycles;
+		bool useZlib;
 	};
 
 	struct Context;

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Larger block sizes than the default will help compression, in the range of 2-3%.
 files may not be compatible with some software.  For example, [PPSSPP][] versions released
 after 2014-10-26 will support larger block sizes.
 
+Avoid DAX where CSOs using larger block sizes are supported, since DAX is less efficient.
+
 LZ4 support is mostly for experimentation.
 
 
@@ -79,7 +81,7 @@ Multiple files may be specified.  Inputs can be iso or cso files.
    --decompress    Write out to raw ISO, decompressing as needed
    --block=N       Specify a block size (default depends on iso size)
                    Many readers only support the 2048 size
-   --format=VER    Specify cso version (options: cso1, cso2, zso)
+   --format=VER    Specify cso version (options: cso1, cso2, zso, dax)
                    These are experimental, default is cso1
    --use-zlib      Enable trials with zlib for deflate compression
    --use-zopfli    Enable trials with Zopfli for deflate compression

--- a/src/compress.h
+++ b/src/compress.h
@@ -47,6 +47,7 @@ enum TaskFlags {
 	TASKFLAG_NO_ALL = TASKFLAG_NO_ZLIB | TASKFLAG_NO_ZOPFLI | TASKFLAG_NO_7ZIP | TASKFLAG_NO_LZ4,
 
 	TASKFLAG_DECOMPRESS = 0x400,
+	TASKFLAG_FMT_DAX = 0x800,
 };
 
 typedef std::function<void (const Task *, TaskStatus status, int64_t pos, int64_t total, int64_t written)> ProgressCallback;

--- a/src/cso.h
+++ b/src/cso.h
@@ -17,6 +17,7 @@ enum CSOFormat {
 	CSO_FMT_CSO1,
 	CSO_FMT_CSO2,
 	CSO_FMT_ZSO,
+	CSO_FMT_DAX,
 };
 
 #ifdef _MSC_VER

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -3,6 +3,7 @@
 #include "buffer_pool.h"
 #include "compress.h"
 #include "cso.h"
+#include "dax.h"
 
 namespace maxcso {
 
@@ -50,14 +51,7 @@ void Output::SetFile(uv_file file, int64_t srcSize, uint32_t blockSize, CSOForma
 	const uint32_t sectors = static_cast<uint32_t>((srcSize + blockSize_ - 1) >> blockShift_);
 	// Start after the header and index, which we'll fill in later.
 	index_ = new uint32_t[sectors + 1];
-	if (flags_ & TASKFLAG_DECOMPRESS) {
-		// Decompressing, so no header.
-		// We still track the index for code simplicity, but throw it away.
-		dstPos_ = 0;
-	} else {
-		// Start after the end of the index data and header.
-		dstPos_ = sizeof(CSOHeader) + (sectors + 1) * sizeof(uint32_t);
-	}
+	dstPos_ = DstFirstSectorPos(sectors);
 
 	// TODO: We might be able to optimize shift better by running through the data.
 	// That would require either a second pass or keeping the entire result in RAM.
@@ -74,6 +68,17 @@ void Output::SetFile(uv_file file, int64_t srcSize, uint32_t blockSize, CSOForma
 		}
 	}
 
+	if (fmt == CSO_FMT_DAX) {
+		if (indexShift_ != 0 || static_cast<uint32_t>(srcSize_) < srcSize_) {
+			finish_(false, "File too large to compress as DAX");
+			return;
+		}
+		if (blockSize_ != DAX_FRAME_SIZE) {
+			finish_(false, "DAX requires a block size of 8192");
+			return;
+		}
+	}
+
 	// If the shift is above 11, the padding could make it need more space.
 	// But that would be > 4 TB anyway, so let's not worry about it.
 	indexAlign_ = 1 << indexShift_;
@@ -85,6 +90,21 @@ void Output::SetFile(uv_file file, int64_t srcSize, uint32_t blockSize, CSOForma
 	const uint32_t lz4MaxCost = static_cast<uint32_t>((lz4MaxCostPercent_ * blockSize_) / 100);
 	for (Sector *sector : freeSectors_) {
 		sector->Setup(loop_, blockSize_, indexAlign_, origMaxCost, lz4MaxCost);
+	}
+}
+
+int64_t Output::DstFirstSectorPos(uint32_t totalSectors) {
+	if (flags_ & TASKFLAG_DECOMPRESS) {
+		// Decompressing, so no header.
+		// We still track the index for code simplicity, but throw it away.
+		return 0;
+	} else if (flags_ & TASKFLAG_FMT_DAX) {
+		// Pos (32 bits) and size (16 bits) per sector, plus header.
+		// TODO: We don't support NC areas, but if we did, we'd have to know them here already...
+		return sizeof(DAXHeader) + totalSectors * (sizeof(uint32_t) + sizeof(uint16_t));
+	} else {
+		// Start after the end of the index data and header.
+		return sizeof(CSOHeader) + (totalSectors + 1) * sizeof(uint32_t);
 	}
 }
 
@@ -200,35 +220,11 @@ void Output::HandleReadySector(Sector *sector) {
 	static char padding[2048] = {0};
 	for (size_t i = 0; i < sectors.size(); ++i) {
 		unsigned int bestSize = sectors[i]->BestSize();
+		if (!UpdateIndex(sectors[i]->Pos(), dstPos, bestSize, sectors[i]->Format())) {
+			return;
+		}
+
 		bufs[nbufs++] = uv_buf_init(reinterpret_cast<char *>(sectors[i]->BestBuffer()), bestSize);
-
-		// Update the index.
-		const int32_t s = static_cast<int32_t>(sectors[i]->Pos() >> blockShift_);
-		index_[s] = static_cast<int32_t>(dstPos >> indexShift_);
-		// CSO2 doesn't use a flag for uncompressed, only the size of the block.
-		if (!sectors[i]->Compressed() && fmt_ != CSO_FMT_CSO2) {
-			index_[s] |= CSO_INDEX_UNCOMPRESSED;
-		}
-		switch (fmt_) {
-		case CSO_FMT_CSO1:
-			if (sectors[i]->Format() == SECTOR_FMT_LZ4) {
-				finish_(false, "LZ4 format not supported within CSO v1 file");
-				return;
-			}
-			break;
-		case CSO_FMT_ZSO:
-			if (sectors[i]->Format() == SECTOR_FMT_DEFLATE) {
-				finish_(false, "Deflate format not supported within ZSO file");
-				return;
-			}
-			break;
-		case CSO_FMT_CSO2:
-			if (sectors[i]->Format() == SECTOR_FMT_LZ4) {
-				index_[s] |= CSO2_INDEX_LZ4;
-			}
-			break;
-		}
-
 		dstPos += bestSize;
 		int32_t padSize = Align(dstPos);
 		if (padSize != 0) {
@@ -276,6 +272,42 @@ void Output::HandleReadySector(Sector *sector) {
 	});
 }
 
+bool Output::UpdateIndex(int64_t srcPos, int64_t dstPos, uint32_t compressedSize, SectorFormat compressedFmt) {
+	const int32_t s = static_cast<int32_t>(srcPos >> blockShift_);
+	index_[s] = static_cast<int32_t>(dstPos >> indexShift_);
+	// CSO2 doesn't use a flag for uncompressed, only the size of the block.
+	if (compressedFmt == SECTOR_FMT_ORIG && fmt_ != CSO_FMT_CSO2 && fmt_ != CSO_FMT_DAX) {
+		index_[s] |= CSO_INDEX_UNCOMPRESSED;
+	}
+	switch (fmt_) {
+	case CSO_FMT_CSO1:
+		if (compressedFmt == SECTOR_FMT_LZ4) {
+			finish_(false, "LZ4 format not supported within CSO v1 file");
+			return false;
+		}
+		break;
+	case CSO_FMT_ZSO:
+		if (compressedFmt == SECTOR_FMT_DEFLATE) {
+			finish_(false, "Deflate format not supported within ZSO file");
+			return false;
+		}
+		break;
+	case CSO_FMT_CSO2:
+		if (compressedFmt == SECTOR_FMT_LZ4) {
+			index_[s] |= CSO2_INDEX_LZ4;
+		}
+		break;
+	case CSO_FMT_DAX:
+		if (compressedFmt != SECTOR_FMT_DEFLATE) {
+			finish_(false, "Sector format must be ZLIB for entire file");
+			return false;
+		}
+		break;
+	}
+
+	return true;
+}
+
 bool Output::ShouldCompress(int64_t pos, uint8_t *buffer) {
 	if (flags_ & TASKFLAG_DECOMPRESS) {
 		return false;
@@ -320,6 +352,20 @@ void Output::Flush() {
 		return;
 	}
 
+	switch (fmt_) {
+	case CSO_FMT_CSO1:
+	case CSO_FMT_CSO2:
+	case CSO_FMT_ZSO:
+		WriteCSOIndex();
+		break;
+
+	case CSO_FMT_DAX:
+		WriteDAXIndex();
+		break;
+	}
+}
+
+void Output::WriteCSOIndex() {
 	CSOHeader *header = new CSOHeader;
 	if (fmt_ == CSO_FMT_ZSO) {
 		memcpy(header->magic, ZSO_MAGIC, sizeof(header->magic));
@@ -349,6 +395,48 @@ void Output::Flush() {
 		}
 		uv_fs_req_cleanup(req);
 		delete header;
+	});
+}
+
+void Output::WriteDAXIndex() {
+	DAXHeader *header = new DAXHeader;
+	memcpy(header->magic, DAX_MAGIC, sizeof(header->magic));
+	header->uncompressed_size = static_cast<uint32_t>(srcSize_);
+	// TODO: 0 because we don't support NC areas in writing currently.
+	header->version = 0;
+	header->nc_areas = 0;
+	header->unused[0] = 0;
+	header->unused[1] = 0;
+	header->unused[2] = 0;
+	header->unused[3] = 0;
+
+	const uint32_t sectors = static_cast<uint32_t>(SrcSizeAligned() >> blockShift_);
+	uint16_t *sizes = new uint16_t[sectors];
+	for (uint32_t i = 0; i < sectors; ++i) {
+		uint32_t size = index_[i + 1] - index_[i];
+		if (size < (1 << 16)) {
+			sizes[i] = size;
+		} else {
+			finish_(false, "Compressed sector larger than 16 bits");
+		}
+	}
+
+	uv_buf_t bufs[3];
+	bufs[0] = uv_buf_init(reinterpret_cast<char *>(header), sizeof(DAXHeader));
+	// We skip the last entry of the index, which is the end.
+	bufs[1] = uv_buf_init(reinterpret_cast<char *>(index_), sectors * sizeof(uint32_t));
+	bufs[2] = uv_buf_init(reinterpret_cast<char *>(sizes), sectors * sizeof(uint16_t));
+	const ssize_t totalBytes = sizeof(DAXHeader) + sectors * (sizeof(uint32_t) + sizeof(uint16_t));
+	uv_.fs_write(loop_, &flush_, file_, bufs, 3, 0, [this, header, sizes, totalBytes](uv_fs_t *req) {
+		if (req->result != totalBytes) {
+			finish_(false, "Unable to write header data");
+		} else {
+			state_ |= STATE_INDEX_WRITTEN;
+			CheckFinish();
+		}
+		uv_fs_req_cleanup(req);
+		delete header;
+		delete [] sizes;
 	});
 }
 

--- a/src/output.h
+++ b/src/output.h
@@ -28,10 +28,16 @@ public:
 private:
 	void CheckFinish();
 	void Flush();
-	int32_t Align(int64_t &pos);
+	void WriteCSOIndex();
+	void WriteDAXIndex();
 	void HandleReadySector(Sector *sector);
 	bool ShouldCompress(int64_t pos, uint8_t *buffer);
+
+	int32_t Align(int64_t &pos);
 	inline int64_t SrcSizeAligned();
+	int64_t DstFirstSectorPos(uint32_t totalSectors);
+
+	bool UpdateIndex(int64_t srcPos, int64_t dstPos, uint32_t compressedSize, SectorFormat compressedFmt);
 
 	enum State {
 		STATE_INIT = 0x00,


### PR DESCRIPTION
This implementation doesn't support NC areas, resulting in a worst-case of a 0.14% larger file.  NC areas require a dynamic header size, which is annoying and might require using a temporary file.

This should hopefully beat other DAX implementations on both compression speed and ratio.

Note that DAX is worse than CSO with a large block size, so it's not very interesting for e.g. PS2.  However, it's better supported for some PSP related software.

This also includes a performance improvement for decompression of DAX files or CSOs with a large block size.

Fixes #15.

-[Unknown]