### PR TITLE
Makefile: Allow setting CFLAGS and CXXFLAGS.

### DIFF
--- a/7zip/Makefile
+++ b/7zip/Makefile
@@ -2,8 +2,11 @@ CC ?= gcc
 CXX ?= g++
 AR ?= ar
 
-CFLAGS += -W -Wall -Wextra -O2
-CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -ICPP
+CFLAGS ?= -O2
+CXXFLAGS ?= -O2
+
+DEF_CFLAGS += -W -Wall -Wextra
+DEF_CXXFLAGS += -W -Wall -Wextra -std=c++11 -ICPP
 
 7ZIP_CXX_SRC = CPP/7zip/Archive/Common/ParseProperties.cpp \
                CPP/7zip/Archive/DeflateProps.cpp \
@@ -33,10 +36,10 @@ CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -ICPP
 7ZIP_C_OBJ =   $(7ZIP_C_SRC:.c=.o)
 
 %.o: %.cpp
-	$(CXX) -c $(CXXFLAGS) -o $@ $<
+	$(CXX) -c $(CXXFLAGS) $(DEF_CXXFLAGS) -o $@ $<
 
 %.o: %.c
-	$(CC) -c $(CFLAGS) -o $@ $<
+	$(CC) -c $(CFLAGS) $(DEF_CFLAGS) -o $@ $<
 
 7zip.a: $(7ZIP_CXX_OBJ) $(7ZIP_C_OBJ)
 	$(AR) rcs $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 CC ?= gcc
 CXX ?= g++
 
-CFLAGS += -W -Wall -Wextra -O2 -Wno-implicit-function-declaration -DNDEBUG=1
-CXXFLAGS += -W -Wall -Wextra -std=c++11 -O2 -Izopfli/src -I7zip -DNDEBUG=1 \
+CFLAGS ?= -O2
+CXXFLAGS ?= -O2
+
+DEF_CFLAGS += -W -Wall -Wextra -Wno-implicit-function-declaration -DNDEBUG=1
+DEF_CXXFLAGS += -W -Wall -Wextra -std=c++11 -Izopfli/src -I7zip -DNDEBUG=1 \
 	-Wno-unused-parameter -pthread
 
 SRC_CXX_SRC = $(wildcard src/*.cpp)
@@ -18,10 +21,10 @@ ZOPFLI_C_SRC = zopfli/src/zopfli/blocksplitter.c zopfli/src/zopfli/cache.c \
 ZOPFLI_C_OBJ = $(ZOPFLI_C_SRC:.c=.o)
 
 %.o: %.cpp
-	$(CXX) -c $(CXXFLAGS) -o $@ $<
+	$(CXX) -c $(CXXFLAGS) $(DEF_CXXFLAGS) -o $@ $<
 
 %.o: %.c
-	$(CC) -c $(CFLAGS) -o $@ $<
+	$(CC) -c $(CFLAGS) $(DEF_CFLAGS) -o $@ $<
 
 maxcso: $(SRC_CXX_OBJ) $(CLI_CXX_OBJ) $(ZOPFLI_C_OBJ) 7zip/7zip.a
 	$(CXX) -o $@ $(CXXFLAGS) $^ -luv -llz4 -lz


### PR DESCRIPTION
This allows the user to set `CFLAGS` and `CXXFLAGS` without clobbering or conflicting with the default `CFLAGS` and `CXXFLAGS`.

For example:
```
CFLAGS=-O3 make
```
Would result in both `-O3` and `-O2` being passed, I think the latter one would take precedence?

Or
```
make CFLAGS=-O2
```
This would result in the default `CFLAGS` vanishing and only `-O2` would be passed.

With this change the user can easily override the optimizations without worrying about the default flags.