### PR TITLE
Makefile: Add install and uninstall targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+
 CC ?= gcc
 CXX ?= g++
 
@@ -28,6 +31,14 @@ maxcso: $(SRC_CXX_OBJ) $(CLI_CXX_OBJ) $(ZOPFLI_C_OBJ) 7zip/7zip.a
 
 7zip/7zip.a:
 	$(MAKE) -C 7zip 7zip.a
+
+install:
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp maxcso $(DESTDIR)$(BINDIR)
+	chmod 0755 $(DESTDIR)$(BINDIR)/maxcso
+
+uninstall:
+	rm -f $(DESTDIR)$(BINDIR)/maxcso
 
 clean:
 	rm -f $(SRC_CXX_OBJ) $(CLI_CXX_OBJ) $(ZOPFLI_C_OBJ) maxcso


### PR DESCRIPTION
This adds `install` and `uninstall` targets to the `Makefile`, this doesn't add much, but offers some convenience to users. The default install paths follow the FHS standard and can be configure with `PREFIX` and `BINDIR`, `DESTDIR` is also supported.

Using `cp(1)` and `chmod(1)` is a little more portable than using `install(1)` which behaves differently on some platforms like Solaris.

I thought about adding `DOCDIR` too, but I am not sure its worth it. Probably easier to just leave that up to the user.