### PR TITLE
Add Docker build image instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ And then just compile using make.
 Aside from gcc/g++ or clang, you will also need liblz4-dev, libdeflate-dev, and libuv1-dev - or
 similar.
 
+The following Dockerfile will produce an Ubuntu image with the needed build dependencies:
+
+    FROM ubuntu:latest
+
+    RUN apt-get update && apt-get install -y build-essential pkgconf zlib1g-dev liblz4-dev libuv1-dev
+
 ### Packages
 
 Community provided packages are available on some platforms under "maxcso".  Please confirm


### PR DESCRIPTION
Add instructions, to the README, for building an Ubuntu Docker image that has all (and only) the needed build dependencies. 

I personally think this is helpful. Even if you don't actually want to build in a Docker (which I usually do these days), it's still useful to know the exact packages required.