### PR TITLE
build: add optional USE_EXTERNAL_LIBDEFLATE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ SRC_LIBDEFLATE = $(SRCDIR)/libdeflate/$(LIBDEFLATE)
 
 .PHONY: all clean install uninstall
 
+all: maxcso
+
 $(OBJDIR)/%.o: $(SRCDIR)/%.cpp $(OBJDIR)/.done
 	$(CXX) -c $(SRC_CXXFLAGS) $(CXXFLAGS) -o $@ $<
 
@@ -99,5 +101,3 @@ clean:
 	rm -rf -- $(OBJDIR)
 	rm -f maxcso
 	$(MAKE) -C $(SRCDIR)/libdeflate clean
-
-all: maxcso

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SRCDIR := $(abspath $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST))))))
 
+USE_EXTERNAL_LIBDEFLATE ?= 0
+
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
@@ -50,16 +52,26 @@ ZOPFLI_C_SRC := $(ZOPFLI_C_DIR)/blocksplitter.c $(ZOPFLI_C_DIR)/cache.c \
 ZOPFLI_C_TMP := $(ZOPFLI_C_SRC:.c=.o)
 ZOPFLI_C_OBJ := $(patsubst $(SRCDIR)/%,$(OBJDIR)/%,$(ZOPFLI_C_TMP))
 
-EXTRA_LIBS =
 ifeq ($(OS),Windows_NT)
-	LIBDEFLATE=libdeflatestatic.lib
-	EXTRA_LIBS += -luuid
+	LIBDEFLATE := libdeflatestatic.lib
+	LIBS += -luuid
 else
-	LIBDEFLATE=libdeflate.a
+	LIBDEFLATE := libdeflate.a
 endif
 
-SRC_7ZIP = $(OBJDIR)/7zip/7zip.a
-SRC_LIBDEFLATE = $(SRCDIR)/libdeflate/$(LIBDEFLATE)
+SRC_7ZIP := $(OBJDIR)/7zip/7zip.a
+SRC_LIBDEFLATE := $(SRCDIR)/libdeflate/$(LIBDEFLATE)
+
+OBJS := $(SRC_CXX_OBJ) $(CLI_CXX_OBJ) $(ZOPFLI_C_OBJ) $(SRC_7ZIP)
+
+ifeq ($(USE_EXTERNAL_LIBDEFLATE), 0)
+	OBJS += $(SRC_LIBDEFLATE)
+else
+	CFLAGS_LIBDEFLATE = $(shell $(PKG_CONFIG) --cflags libdeflate)
+	LIBS_LIBDEFLATE = $(shell $(PKG_CONFIG) --libs libdeflate)
+	SRC_CXXFLAGS += $(CFLAGS_LIBDEFLATE)
+	LIBS += $(LIBS_LIBDEFLATE)
+endif
 
 .PHONY: all clean install uninstall
 
@@ -71,9 +83,8 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp $(OBJDIR)/.done
 $(OBJDIR)/%.o: $(SRCDIR)/%.c $(OBJDIR)/.done
 	$(CC) -c $(SRC_CFLAGS) $(CFLAGS) -o $@ $<
 
-# TODO: Perhaps detect and use system libdeflate if available.
-maxcso: $(SRC_CXX_OBJ) $(CLI_CXX_OBJ) $(ZOPFLI_C_OBJ) $(SRC_7ZIP) $(SRC_LIBDEFLATE)
-	$(CXX) $(LDFLAGS) -o $@ $(SRC_CXXFLAGS) $(CXXFLAGS) $^ $(LIBS) $(EXTRA_LIBS)
+maxcso: $(OBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(SRC_CXXFLAGS) $(CXXFLAGS) $^ $(LIBS)
 
 $(SRC_7ZIP):
 	$(MAKE) -f $(SRCDIR)/7zip/Makefile 7zip.a

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ CXXFLAGS ?= $(CFLAGS)
 
 PKG_CONFIG ?= pkg-config
 
-CFLAGS_UV := $(shell $(PKG_CONFIG) --cflags libuv)
-LIBS_UV := $(shell $(PKG_CONFIG) --libs libuv)
+CFLAGS_UV = $(shell $(PKG_CONFIG) --cflags libuv)
+LIBS_UV = $(shell $(PKG_CONFIG) --libs libuv)
 
-CFLAGS_LZ4 := $(shell $(PKG_CONFIG) --cflags liblz4)
-LIBS_LZ4 := $(shell $(PKG_CONFIG) --libs liblz4)
+CFLAGS_LZ4 = $(shell $(PKG_CONFIG) --cflags liblz4)
+LIBS_LZ4 = $(shell $(PKG_CONFIG) --libs liblz4)
 
-CFLAGS_ZLIB := $(shell $(PKG_CONFIG) --cflags zlib)
-LIBS_ZLIB := $(shell $(PKG_CONFIG) --libs zlib)
+CFLAGS_ZLIB = $(shell $(PKG_CONFIG) --cflags zlib)
+LIBS_ZLIB = $(shell $(PKG_CONFIG) --libs zlib)
 
 DEP_FLAGS := $(CFLAGS_UV) $(CFLAGS_LZ4) $(CFLAGS_ZLIB)
 LIBS := $(LIBS_UV) $(LIBS_LZ4) $(LIBS_ZLIB)

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ endif
 SRC_7ZIP = $(OBJDIR)/7zip/7zip.a
 SRC_LIBDEFLATE = $(SRCDIR)/libdeflate/$(LIBDEFLATE)
 
+.PHONY: all clean install uninstall
+
 $(OBJDIR)/%.o: $(SRCDIR)/%.cpp $(OBJDIR)/.done
 	$(CXX) -c $(SRC_CXXFLAGS) $(CXXFLAGS) -o $@ $<
 
@@ -99,5 +101,3 @@ clean:
 	$(MAKE) -C $(SRCDIR)/libdeflate clean
 
 all: maxcso
-
-.PHONY: clean all


### PR DESCRIPTION
When setting `USE_EXTERNAL_LIBDEFLATE=1` as a `make(1)` argument a system version will be used and otherwise it will use the vendored libdeflate.

This was tested using `libdeflate-1.19` that was recently added to Gentoo (https://github.com/gentoo/gentoo/commit/bae8948c83b015ea65a7542ab3499d241a001905).

There are also a few trivial commits to improve the Makefile.