### PR TITLE
Add CMakeLists.txt to support CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ project(
 
 
 # Prevent cmake from running in the root directory to avoid replacing the original Makefile
-get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
-if(NOT not_top)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR "Generating CMake build files in the project root directory is not allowed. Please create a new directory and run cmake from there, or use the command 'cmake -B /path/to/build_directory' to specify a build directory.")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.8)
+project(
+	maxcso
+	VERSION 1.13.0
+	DESCRIPTION
+		"A fast ISO to CSO compression program for use with PSP and PS2 emulators"
+	HOMEPAGE_URL https://github.com/unknownbrackets/maxcso
+	LANGUAGES C CXX
+)
+
+
+# Prevent cmake from running in the root directory to avoid replacing the original Makefile
+get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
+if(NOT not_top)
+    message(FATAL_ERROR "Generating CMake build files in the project root directory is not allowed. Please create a new directory and run cmake from there, or use the command 'cmake -B /path/to/build_directory' to specify a build directory.")
+endif()
+
+
+set(CMAKE_CXX_STANDARD 11)
+add_compile_options(
+	-W
+	-Wall
+	-Wextra
+	"$<$<COMPILE_LANGUAGE:C>:-Wno-implicit-function-declaration>"
+	"$<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter;-Wno-unused-variable>"
+)
+
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(LIBDEFLATE REQUIRED libdeflate)
+pkg_check_modules(LIBUV REQUIRED libuv)
+pkg_check_modules(LZ4 REQUIRED liblz4)
+pkg_check_modules(ZLIB REQUIRED zlib)
+
+if(WIN32)
+	pkg_check_modules(UUID uuid REQUIRED)
+endif()
+
+# Add 7zip and zopfli libraries
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(7zip)
+include(Zopfli)
+
+
+add_executable(
+	maxcso
+	cli/cli.cpp
+	cli/winargs.cpp
+	cli/winglob.cpp
+	src/buffer_pool.cpp
+	src/checksum.cpp
+	src/compress.cpp
+	src/input.cpp
+	src/output.cpp
+	src/sector.cpp
+	src/uv_helper.cpp
+)
+target_include_directories(
+	maxcso
+	PRIVATE
+		${LIBDEFLATE_INCLUDE_DIRS}
+		${LIBUV_INCLUDE_DIRS}
+		${LZ4_INCLUDE_DIRS}
+		${UUID_INCLUDE_DIRS}
+		${ZLIB_INCLUDE_DIRS}
+)
+target_link_libraries(
+	maxcso
+	PRIVATE
+		${LIBDEFLATE_LIBRARIES}
+		${LIBUV_LIBRARIES}
+		${LZ4_LIBRARIES}
+		${UUID_LIBRARIES}
+		${ZLIB_LIBRARIES}
+		7zip
+		zopfli
+		Threads::Threads
+)
+
+
+include(GNUInstallDirs)
+install(TARGETS maxcso DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+	FILES ${CMAKE_SOURCE_DIR}/maxcso.1
+	DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+)

--- a/cmake/7zip.cmake
+++ b/cmake/7zip.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 
-set(7ZIP_SRC_DIR ${CMAKE_SOURCE_DIR}/7zip)
+set(7ZIP_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/7zip)
 add_library(
 	7zip
-	OBJECT
+	STATIC
 	${7ZIP_SRC_DIR}/C/Alloc.c
 	${7ZIP_SRC_DIR}/C/HuffEnc.c
 	${7ZIP_SRC_DIR}/C/LzFind.c

--- a/cmake/7zip.cmake
+++ b/cmake/7zip.cmake
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.8)
+
+set(7ZIP_SRC_DIR ${CMAKE_SOURCE_DIR}/7zip)
+add_library(
+	7zip
+	OBJECT
+	${7ZIP_SRC_DIR}/C/Alloc.c
+	${7ZIP_SRC_DIR}/C/HuffEnc.c
+	${7ZIP_SRC_DIR}/C/LzFind.c
+	${7ZIP_SRC_DIR}/C/Sort.c
+	${7ZIP_SRC_DIR}/CPP/7zip/Archive/Common/ParseProperties.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Archive/DeflateProps.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Common/CWrappers.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Common/FileStreams.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Common/InBuffer.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Common/OutBuffer.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Common/StreamUtils.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Compress/BitlDecoder.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Compress/DeflateDecoder.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Compress/DeflateEncoder.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Compress/LzOutWindow.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Compress/ZlibDecoder.cpp
+	${7ZIP_SRC_DIR}/CPP/7zip/Compress/ZlibEncoder.cpp
+	${7ZIP_SRC_DIR}/CPP/Common/MyString.cpp
+	${7ZIP_SRC_DIR}/CPP/Common/StringConvert.cpp
+	${7ZIP_SRC_DIR}/CPP/Common/StringToInt.cpp
+	${7ZIP_SRC_DIR}/CPP/NotWindows/FileIO.cpp
+	${7ZIP_SRC_DIR}/CPP/NotWindows/MyWindows.cpp
+	${7ZIP_SRC_DIR}/CPP/Windows/PropVariant.cpp
+	${7ZIP_SRC_DIR}/deflate7z.cpp
+)
+target_include_directories(7zip PUBLIC ${7ZIP_SRC_DIR} ${7ZIP_SRC_DIR}/CPP)

--- a/cmake/Zopfli.cmake
+++ b/cmake/Zopfli.cmake
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+
+set(ZOPFLI_SRC_DIR ${CMAKE_SOURCE_DIR}/zopfli/src/zopfli)
+add_library(
+	zopfli
+	OBJECT
+	${ZOPFLI_SRC_DIR}/blocksplitter.c
+	${ZOPFLI_SRC_DIR}/cache.c
+	${ZOPFLI_SRC_DIR}/deflate.c
+	${ZOPFLI_SRC_DIR}/gzip_container.c
+	${ZOPFLI_SRC_DIR}/hash.c
+	${ZOPFLI_SRC_DIR}/katajainen.c
+	${ZOPFLI_SRC_DIR}/lz77.c
+	${ZOPFLI_SRC_DIR}/squeeze.c
+	${ZOPFLI_SRC_DIR}/tree.c
+	${ZOPFLI_SRC_DIR}/util.c
+	${ZOPFLI_SRC_DIR}/zlib_container.c
+	${ZOPFLI_SRC_DIR}/zopfli_lib.c
+)
+target_include_directories(zopfli PUBLIC ${ZOPFLI_SRC_DIR}/..)

--- a/cmake/Zopfli.cmake
+++ b/cmake/Zopfli.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-set(ZOPFLI_SRC_DIR ${CMAKE_SOURCE_DIR}/zopfli/src/zopfli)
+set(ZOPFLI_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zopfli/src/zopfli)
 add_library(
 	zopfli
 	OBJECT


### PR DESCRIPTION
This is an addition to the existing Makefile build system and is not intended to replace it. The CMake configuration is set up to prevent running cmake in the project root directory to avoid overwriting the original Makefile.