### PR TITLE
Add homebrew tap for macOS users

### DIFF
--- a/Formula/m/maxcso.rb
+++ b/Formula/m/maxcso.rb
@@ -1,4 +1,4 @@
-class maxcso < Formula
+class MaxCSO < Formula
   include Language::Python::Virtualenv
 
   desc "Fast cso compressor"

--- a/Formula/m/maxcso.rb
+++ b/Formula/m/maxcso.rb
@@ -1,5 +1,4 @@
 class Maxcso < Formula
-  include Language::Python::Virtualenv
 
   desc "Fast cso compressor"
   homepage "https://github.com/unknownbrackets/maxcso"

--- a/Formula/m/maxcso.rb
+++ b/Formula/m/maxcso.rb
@@ -1,0 +1,24 @@
+class maxcso < Formula
+  include Language::Python::Virtualenv
+
+  desc "Fast cso compressor"
+  homepage "https://github.com/unknownbrackets/maxcso"
+  url "https://github.com/unknownbrackets/maxcso/archive/refs/tags/v1.13.0.zip"
+  sha256 "09df940ddd48a299aa9a1aed85c495aea1be8b9185cab5b893f6cd6bdb3fc822"
+  license "ISC License"
+
+  depends_on "lz4"
+  depends_on "libuv"
+  depends_on "libdeflate"
+  depends_on "pkg-config"
+
+  def install
+    system "make"
+    bin.install "maxcso"
+  end
+
+  test do
+    system "#{bin}/maxcso", "--help"
+  end
+
+end

--- a/Formula/m/maxcso.rb
+++ b/Formula/m/maxcso.rb
@@ -1,4 +1,4 @@
-class MaxCSO < Formula
+class Maxcso < Formula
   include Language::Python::Virtualenv
 
   desc "Fast cso compressor"


### PR DESCRIPTION
Minimally tested build on macOS 14.5 (MBP 14" 2021) using Homebrew.

This only adds a formula so that it can be compiled and updated through homebrew via `brew install unknownbrackets/maxcso/maxcso`, taking out the need to manually install the dependencies and issue the make command.

Maintaining this should just need the url for the latest source release and it's sha256 sum.