### PR TITLE
uv_write fix for MSVC Debug

### DIFF
--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -453,8 +453,10 @@ int main(int argc, char *argv[]) {
 	std::fill(std::begin(history), std::end(history), History{0, next});
 
 	std::string statusInfo;
+#ifndef WIN_UV_WRITE_WORKAROUND
 	uv_write_t write_req;
 	uv_buf_t bufs[2];
+#endif
 
 	maxcso::ProgressCallback progress = [&] (const maxcso::Task *task, maxcso::TaskStatus status, int64_t pos, int64_t total, int64_t written) {
 		if (!formatting) {
@@ -507,7 +509,10 @@ int main(int argc, char *argv[]) {
 			statusInfo = task->input + ": " + statusInfo;
 		}
 
+#ifndef WIN_UV_WRITE_WORKAROUND
 		unsigned int nbufs = 0;
+#endif // DEBUG
+
 		if (formatting) {
 #ifdef WIN_UV_WRITE_WORKAROUND
 			heap_write_req* wr = (heap_write_req*)malloc(sizeof(*wr));

--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -14,7 +14,9 @@
 #include "../src/checksum.h"
 #include "uv.h"
 
-#if defined(_MSC_VER) && !defined(NDEBUG)
+//When compiling on MSVC an assertion will trigger in the libuv library on uv_write.
+//This is a workaround to avoid it. The workarund is only applied to MSVC Debug builds.
+#if defined(_MSC_VER) && !defined(NDEBUG) 
 #define WIN_UV_WRITE_WORKAROUND
 #endif
 

--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -14,7 +14,7 @@
 #include "../src/checksum.h"
 #include "uv.h"
 
-#if defined(_MSC_VER) && !defined(_llvm__) //TODO: check which msc ver bricked this && _MSC_VER
+#if defined(_MSC_VER) && !defined(NDEBUG)
 #define WIN_UV_WRITE_WORKAROUND
 #endif
 

--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -14,6 +14,23 @@
 #include "../src/checksum.h"
 #include "uv.h"
 
+#if defined(_MSC_VER) && !defined(_llvm__) //TODO: check which msc ver bricked this && _MSC_VER
+#define WIN_UV_WRITE_WORKAROUND
+#endif
+
+#if defined WIN_UV_WRITE_WORKAROUND
+struct heap_write_req {
+	uv_write_t req;
+	char* data; // allocated copy of dynamic text (nullptr if none)
+};
+
+static void heap_write_cb(uv_write_t* r, int /*status*/) {
+	heap_write_req* wr = reinterpret_cast<heap_write_req*>(r);
+	if (wr->data) free(wr->data);
+	free(wr);
+}
+#endif
+
 void show_version() {
 	fprintf(stderr, "maxcso v%s\n", maxcso::VERSION);
 }
@@ -492,9 +509,28 @@ int main(int argc, char *argv[]) {
 
 		unsigned int nbufs = 0;
 		if (formatting) {
+#ifdef WIN_UV_WRITE_WORKAROUND
+			heap_write_req* wr = (heap_write_req*)malloc(sizeof(*wr));
+			if (!wr) return;
+			// copy status string
+			size_t len = statusInfo.size();
+			char* copy = (char*)malloc(len + 1);
+			if (!copy) { free(wr); return; }
+			memcpy(copy, statusInfo.c_str(), len + 1);
+			wr->data = copy;
+
+			uv_buf_t bufs[2];
+			unsigned nbufs = 0;
+			bufs[nbufs++] = ::uv_buf_init(ANSI_RESET_LINE);           // literal OK
+			bufs[nbufs++] = ::uv_buf_init(copy, (unsigned)len);      // heap copy
+
+			int rc = uv_write(&wr->req, reinterpret_cast<uv_stream_t*>(&tty), bufs, nbufs, heap_write_cb);
+			if (rc != 0) { free(copy); free(wr); /* handle error if needed */ }
+#else
 			bufs[nbufs++] = uv_buf_init(ANSI_RESET_LINE);
 			bufs[nbufs++] = uv_buf_init(statusInfo);
 			uv_write(&write_req, reinterpret_cast<uv_stream_t *>(&tty), bufs, nbufs, nullptr);
+#endif
 		} else {
 			fprintf(stderr, "%s", statusInfo.c_str());
 		}
@@ -512,8 +548,27 @@ int main(int argc, char *argv[]) {
 		const std::string prefix = status == maxcso::TASK_SUCCESS ? "" : "Error while processing ";
 		statusInfo = (formatting ? ANSI_RESET_LINE : "") + prefix + task->input + ": " + reason + "\n";
 		if (formatting) {
+#ifdef WIN_UV_WRITE_WORKAROUND
+			heap_write_req* wr = (heap_write_req*)malloc(sizeof(*wr));
+			if (!wr) return;
+			// copy status string
+			size_t len = statusInfo.size();
+			char* copy = (char*)malloc(len + 1);
+			if (!copy) { free(wr); return; }
+			memcpy(copy, statusInfo.c_str(), len + 1);
+			wr->data = copy;
+
+			uv_buf_t bufs[2];
+			unsigned nbufs = 0;
+			bufs[nbufs++] = ::uv_buf_init(ANSI_RESET_LINE);           // literal OK
+			bufs[nbufs++] = ::uv_buf_init(copy, (unsigned)len);      // heap copy
+
+			int rc = uv_write(&wr->req, reinterpret_cast<uv_stream_t*>(&tty), bufs, nbufs, heap_write_cb);
+			if (rc != 0) { free(copy); free(wr); /* handle error if needed */ }
+#else
 			bufs[0] = uv_buf_init(statusInfo);
 			uv_write(&write_req, reinterpret_cast<uv_stream_t *>(&tty), bufs, 1, nullptr);
+#endif
 		} else {
 			fprintf(stderr, "%s", statusInfo.c_str());
 		}


### PR DESCRIPTION
Currently an assertion triggers when compiling and running this project on MSVC with the Debug build target.
I assume that Microsoft changed something in the compilation process which caused this issue, since the issue doesn't occur when compiling with make and a couple of months ago I could still compile Debug on MSVC.

This is a workaround that fixes the issue, with little to no performance impact.
The fix is only applied to Debug Targets on MSVC.
To be fair there is little reason to use this target, aside from debugging, as it is much slower than Release (not the fault of the workaround, I tested it on the Release Target and it showed similar performance to the current Binary on the Releases Page). 